### PR TITLE
Fix zero-based trial progress display

### DIFF
--- a/webversion.html
+++ b/webversion.html
@@ -729,7 +729,8 @@
       const progress = document.getElementById('progress');
       const totalBlocks = config.blocks.length || 0;
       const currentBlock = Math.min(state.currentBlock + 1, totalBlocks || 1);
-      const trialNum = Math.min(state.currentTrial, config.trialsPerBlock);
+      // Display trials using 1-based indexing so the first trial shows as 1
+      const trialNum = Math.min(state.currentTrial + 1, config.trialsPerBlock);
       progress.textContent = `Block ${currentBlock}/${totalBlocks} | Trial ${trialNum}/${config.trialsPerBlock}`;
     }
 


### PR DESCRIPTION
## Summary
- ensure progress tracker uses 1-based trial numbering for user-facing display

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689919cbc1bc8326b0cd253732dc9a52