### PR TITLE
Handle missing localStorage to allow experiment to start

### DIFF
--- a/webversion.html
+++ b/webversion.html
@@ -256,8 +256,15 @@
     // Instant local ID, background sync to Sheets
     function nextIdLocal(groupCode) {
       const key = `lastId_${groupCode}`;
-      const n = (parseInt(localStorage.getItem(key) || '0', 10) + 1);
-      localStorage.setItem(key, String(n));
+      let n = 0;
+      try {
+        n = parseInt(localStorage.getItem(key) || '0', 10) + 1;
+        localStorage.setItem(key, String(n));
+      } catch (e) {
+        if (!nextIdLocal.memory) nextIdLocal.memory = {};
+        n = (nextIdLocal.memory[groupCode] || 0) + 1;
+        nextIdLocal.memory[groupCode] = n;
+      }
       return String(n).padStart(3, '0');
     }
     function syncIdToSheets(groupCode, fullId) {


### PR DESCRIPTION
## Summary
- prevent crash when localStorage is unavailable by falling back to in-memory counter for participant IDs
- allows participants to proceed past demographic screen even in private/incognito modes

## Testing
- `node -e "const fs=require('fs'); const html=fs.readFileSync('webversion.html','utf-8'); const script=html.match(/function nextIdLocal[\s\S]*?return String(n).padStart(3, '0');\n\s*}/)[0]; eval(script); console.log(nextIdLocal('DF')); console.log(nextIdLocal('DF')); const _next=nextIdLocal; delete global.localStorage; console.log(_next('DF')); console.log(_next('DF'));"`

------
https://chatgpt.com/codex/tasks/task_e_68991b5677688326b61a36ffd4d64e85