### PR TITLE
Standardize control stimulus IDs and reposition D-pad

### DIFF
--- a/stimulus_mappings.js
+++ b/stimulus_mappings.js
@@ -74,15 +74,15 @@ const stimulusMapping = {
         { id: "hard_032", file: "stimuli/hard/32.png", egocentric_correct: "down", allocentric_correct: "right" }
     ],
     control: [
-        { id: "control_01", file: "stimuli/control/1.png", egocentric_correct: "right", allocentric_correct: "right" },
-        { id: "control_02", file: "stimuli/control/2.png", egocentric_correct: "up", allocentric_correct: "up" },
-        { id: "control_03", file: "stimuli/control/3.png", egocentric_correct: "down", allocentric_correct: "down" },
-        { id: "control_04", file: "stimuli/control/4.png", egocentric_correct: "left", allocentric_correct: "left" },
-        { id: "control_05", file: "stimuli/control/5.png", egocentric_correct: "left", allocentric_correct: "left" },
-        { id: "control_06", file: "stimuli/control/6.png", egocentric_correct: "up", allocentric_correct: "up" },
-        { id: "control_07", file: "stimuli/control/7.png", egocentric_correct: "right", allocentric_correct: "right" },
-        { id: "control_08", file: "stimuli/control/8.png", egocentric_correct: "up", allocentric_correct: "up" },
-        { id: "control_09", file: "stimuli/control/9.png", egocentric_correct: "left", allocentric_correct: "left" },
+        { id: "control_001", file: "stimuli/control/1.png", egocentric_correct: "right", allocentric_correct: "right" },
+        { id: "control_002", file: "stimuli/control/2.png", egocentric_correct: "up", allocentric_correct: "up" },
+        { id: "control_003", file: "stimuli/control/3.png", egocentric_correct: "down", allocentric_correct: "down" },
+        { id: "control_004", file: "stimuli/control/4.png", egocentric_correct: "left", allocentric_correct: "left" },
+        { id: "control_005", file: "stimuli/control/5.png", egocentric_correct: "left", allocentric_correct: "left" },
+        { id: "control_006", file: "stimuli/control/6.png", egocentric_correct: "up", allocentric_correct: "up" },
+        { id: "control_007", file: "stimuli/control/7.png", egocentric_correct: "right", allocentric_correct: "right" },
+        { id: "control_008", file: "stimuli/control/8.png", egocentric_correct: "up", allocentric_correct: "up" },
+        { id: "control_009", file: "stimuli/control/9.png", egocentric_correct: "left", allocentric_correct: "left" },
         { id: "control_010", file: "stimuli/control/10.png", egocentric_correct: "down", allocentric_correct: "down" }
     ]
 };

--- a/webversion.html
+++ b/webversion.html
@@ -73,7 +73,7 @@
     /* Touchscreen D-pad */
     .dpad {
       position: absolute;
-      bottom: 20px;
+      bottom: 80px;
       width: 180px;
       height: 180px;
       display: none;
@@ -194,6 +194,9 @@
       HNF: 'Hearing individuals who are not fluent in sign language',
       HNS: 'Hearing individuals who do not know sign language'
     };
+
+    // Detect mobile/touch devices to conditionally show on-screen controls
+    const isMobile = /Mobi|Android|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
 
     // Block plan mirrors your Python/earlier JS
     const config = {
@@ -618,32 +621,34 @@ UP / DOWN / LEFT / RIGHT
       updateProgress();
     }
 
-    /********* PRESENT & RESPOND *********/
-    function presentStimulus(stimulus, navType, difficulty){
-      state.currentStimulus = stimulus;
-      state.currentNavType = navType;
-      state.currentDifficulty = difficulty;
+      /********* PRESENT & RESPOND *********/
+      function presentStimulus(stimulus, navType, difficulty){
+        state.currentStimulus = stimulus;
+        state.currentNavType = navType;
+        state.currentDifficulty = difficulty;
 
-      if (state.isPractice) setPracticeBadgeAndLegend(navType);
+        if (state.isPractice) setPracticeBadgeAndLegend(navType);
 
-      const img = document.getElementById('stimulus-image');
-      const fix = document.getElementById('fixation');
-      const dpad = document.getElementById('touch-controls');
+        const img = document.getElementById('stimulus-image');
+        const fix = document.getElementById('fixation');
+        const dpad = document.getElementById('touch-controls');
 
-      window.focus();
-      img.style.display = 'none';
-      fix.style.display = 'block';
-      dpad.style.display = 'none';
-      showScreen('stimulus-screen');
+        window.focus();
+        img.style.display = 'none';
+        fix.style.display = 'block';
+        dpad.style.display = 'none';
+        showScreen('stimulus-screen');
 
-      setTimeout(()=> {
-        fix.style.display = 'none';
-        img.src = stimulus.file;
-        img.style.display = 'block';
-        state.stimulusOnsetTime = performance.now();
-        dpad.style.display = 'block';
+        setTimeout(()=> {
+          fix.style.display = 'none';
+          img.src = stimulus.file;
+          img.style.display = 'block';
+          state.stimulusOnsetTime = performance.now();
+          if (isMobile) {
+            dpad.style.display = 'block';
+          }
 
-        state.onKeyHandler = (e)=> {
+          state.onKeyHandler = (e)=> {
           if (['ArrowUp','ArrowDown','ArrowLeft','ArrowRight'].includes(e.key)) e.preventDefault();
           handleResponse(e);
         };
@@ -817,10 +822,12 @@ UP / DOWN / LEFT / RIGHT
     }, { passive:false });
 
     // Enable start when form is complete (no mapping gating)
-    document.addEventListener('DOMContentLoaded', () => {
-      maybeEnableStart();
-      setupTouchControls();
-    });
+      document.addEventListener('DOMContentLoaded', () => {
+        maybeEnableStart();
+        if (isMobile) {
+          setupTouchControls();
+        }
+      });
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Standardize control stimulus IDs with zero padding for consistency
- Move on-screen D-pad higher to keep bottom arrow visible
- Display touch D-pad only on mobile devices

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node -e "const fs=require('fs');const vm=require('vm');const code=fs.readFileSync('stimulus_mappings.js','utf8');const sandbox={};vm.createContext(sandbox);vm.runInContext(code+';this.stimulusMapping=stimulusMapping', sandbox);console.log('control entries:', sandbox.stimulusMapping.control.length);"`


------
https://chatgpt.com/codex/tasks/task_e_689a565ad32483268577dc147de0a05b