### PR TITLE
Add initials field to opening screen

### DIFF
--- a/index.html
+++ b/index.html
@@ -63,10 +63,22 @@
             margin: 30px 0;
             transition: all 0.3s ease;
             box-shadow: 0 4px 15px rgba(102, 126, 234, 0.4);
+            border: none;
+            cursor: pointer;
         }
         .start-button:hover {
             transform: translateY(-2px);
             box-shadow: 0 7px 20px rgba(102, 126, 234, 0.5);
+        }
+        .initials-input {
+            margin: 20px 0;
+        }
+        .initials-input input {
+            padding: 10px;
+            font-size: 16px;
+            border: 1px solid #ccc;
+            border-radius: 5px;
+            width: 200px;
         }
         .info-box {
             background: #f8f9fa;
@@ -151,7 +163,12 @@
             </ul>
         </div>
         
-        <a href="webversion.html" class="start-button">Begin Experiment</a>
+        <div class="initials-input">
+            <label for="initials"><strong>Your initials:</strong></label><br>
+            <input type="text" id="initials" maxlength="3" placeholder="e.g., ABC">
+        </div>
+
+        <button class="start-button" onclick="startExperiment()">Begin Experiment</button>
         
         <div class="info-box">
             <h3>What You'll Do</h3>
@@ -171,5 +188,16 @@
             </p>
         </div>
     </div>
+    <script>
+        function startExperiment(){
+            const initials = document.getElementById('initials').value.trim();
+            if(!initials){
+                alert('Please enter your initials.');
+                return;
+            }
+            localStorage.setItem('participantInitials', initials);
+            window.location.href = 'webversion.html';
+        }
+    </script>
 </body>
 </html>

--- a/webversion.html
+++ b/webversion.html
@@ -446,6 +446,8 @@ UP / DOWN / LEFT / RIGHT
       const age = document.getElementById('age').value;
       const gender = document.getElementById('gender').value;
       const handedness = document.getElementById('handedness').value;
+      const initials = localStorage.getItem('participantInitials') || '';
+      localStorage.removeItem('participantInitials');
       if (!group || !age || !gender || !handedness) return alert('Please fill in all required fields (Age, Gender, Handedness)');
 
       const btn = document.getElementById('start-button');
@@ -468,7 +470,7 @@ UP / DOWN / LEFT / RIGHT
         assignedId = `${group}-tmp-${Date.now().toString(36)}-${hex}`;
       }
 
-      state.participantInfo = { id: assignedId, group, age, gender, handedness, timestamp: new Date().toISOString() };
+      state.participantInfo = { id: assignedId, initials, group, age, gender, handedness, timestamp: new Date().toISOString() };
 
       // Position on-screen dpad based on handedness (only if mobile)
       if (isMobile) {
@@ -728,6 +730,7 @@ UP / DOWN / LEFT / RIGHT
 
       const common = {
         participant_id: state.participantInfo.id,
+        participant_initials: state.participantInfo.initials,
         participant_group: state.participantInfo.group,
         age: state.participantInfo.age,
         gender: state.participantInfo.gender,
@@ -799,6 +802,7 @@ UP / DOWN / LEFT / RIGHT
 
   const summary = {
     participant_id: state.participantInfo.id,
+    participant_initials: state.participantInfo.initials,
     participant_group: state.participantInfo.group,
     age: state.participantInfo.age,
     gender: state.participantInfo.gender,


### PR DESCRIPTION
## Summary
- Allow participants to enter initials on the landing page
- Store and forward initials to the experiment for trial and summary data

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a482f282e88326b4fd9675f47e67df