### PR TITLE
Add participant initials to data entry and tracking sheet

### DIFF
--- a/google-apps-script.gs
+++ b/google-apps-script.gs
@@ -33,10 +33,12 @@ function getSheet_() {
 
 function appendTrialRow_(data) {
   const sheet = getSheet_();
+  ensureInitialsColumn_(sheet);
   const ts = new Date().toISOString();
   sheet.appendRow([
     ts,
     data.participant_id || '',
+    data.participant_initials || '',
     data.participant_group || '',
     data.age || '',
     data.gender || '',
@@ -52,6 +54,15 @@ function appendTrialRow_(data) {
     data.rt_ms,
     data.user_agent || ''
   ]);
+}
+
+// Ensure the sheet has a column for participant initials without overwriting existing data
+function ensureInitialsColumn_(sheet) {
+  const firstRow = sheet.getRange(1, 1, 1, sheet.getLastColumn()).getValues()[0];
+  if (firstRow.indexOf('participant_initials') === -1) {
+    sheet.insertColumnAfter(2);
+    sheet.getRange(1, 3).setValue('participant_initials');
+  }
 }
 
 /** ID counter with locking **/

--- a/index.html
+++ b/index.html
@@ -70,16 +70,6 @@
             transform: translateY(-2px);
             box-shadow: 0 7px 20px rgba(102, 126, 234, 0.5);
         }
-        .initials-input {
-            margin: 20px 0;
-        }
-        .initials-input input {
-            padding: 10px;
-            font-size: 16px;
-            border: 1px solid #ccc;
-            border-radius: 5px;
-            width: 200px;
-        }
         .info-box {
             background: #f8f9fa;
             padding: 25px;
@@ -163,11 +153,6 @@
             </ul>
         </div>
         
-        <div class="initials-input">
-            <label for="initials"><strong>Your initials:</strong></label><br>
-            <input type="text" id="initials" maxlength="3" placeholder="e.g., ABC" style="text-transform: uppercase;">
-        </div>
-
         <button class="start-button" onclick="startExperiment()">Begin Experiment</button>
         
         <div class="info-box">
@@ -190,12 +175,6 @@
     </div>
     <script>
         function startExperiment(){
-            const initials = document.getElementById('initials').value.trim();
-            if(!initials){
-                alert('Please enter your initials.');
-                return;
-            }
-            localStorage.setItem('participantInitials', initials);
             window.location.href = 'webversion.html';
         }
     </script>

--- a/webversion.html
+++ b/webversion.html
@@ -119,6 +119,11 @@
       <div id="group-desc" class="hint"></div>
 
       <div class="form-group">
+        <label>Initials:</label>
+        <input type="text" id="initials" maxlength="3" oninput="maybeEnableStart()" style="text-transform: uppercase;">
+      </div>
+
+      <div class="form-group">
         <label>Age:</label>
         <input type="number" id="age" min="18" max="100" oninput="maybeEnableStart()">
       </div>
@@ -467,24 +472,24 @@ UP / DOWN / LEFT / RIGHT
     }
     function maybeEnableStart(){
       const group = document.getElementById('participant-group').value;
+      const initials = document.getElementById('initials').value.trim();
       const age = document.getElementById('age').value;
       const gender = document.getElementById('gender').value;
       const handedness = document.getElementById('handedness').value;
       const startBtn = document.getElementById('start-button');
-      const ready = group && age && gender && handedness;
+      const ready = group && initials && age && gender && handedness;
       startBtn.disabled = !ready;
-      startBtn.textContent = ready ? 'Start Experiment' : 'Please select your group first';
+      startBtn.textContent = ready ? 'Start Experiment' : 'Fill in all fields to start';
     }
 
     /********* START *********/
     async function startExperiment(){
       const group = document.getElementById('participant-group').value;
+      const initials = document.getElementById('initials').value.trim().toUpperCase();
       const age = document.getElementById('age').value;
       const gender = document.getElementById('gender').value;
       const handedness = document.getElementById('handedness').value;
-      const initials = localStorage.getItem('participantInitials') || '';
-      localStorage.removeItem('participantInitials');
-      if (!group || !age || !gender || !handedness) return alert('Please fill in all required fields (Age, Gender, Handedness)');
+      if (!group || !initials || !age || !gender || !handedness) return alert('Please fill in all required fields (Initials, Age, Gender, Handedness)');
 
       const btn = document.getElementById('start-button');
       btn.disabled = true; btn.textContent = 'Assigning ID…';


### PR DESCRIPTION
## Summary
- Move participant initials entry into main data collection form
- Send initials with each trial and add column in Google Sheets via Apps Script
- Remove separate initials prompt on landing page

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a8da84ae9c83269f9d0397e6406234