### PR TITLE
refactor: use main element for container

### DIFF
--- a/index.html
+++ b/index.html
@@ -123,7 +123,7 @@
     </style>
 </head>
 <body>
-    <div class="container">
+    <main class="container">
         <h1>Spatial Navigation Task</h1>
         <p class="subtitle">Sign Language & Spatial Cognition Research</p>
         
@@ -165,13 +165,13 @@
             <p style="margin-top: 15px;">Your responses help us understand how sign language experience affects spatial thinking.</p>
         </div>
         
-        <div class="footer">
-            <p>For technical support or questions, contact the research team at action.brain.lab@gallaudet.edu.</p>
-            <p style="margin-top: 10px; font-size: 12px;">
-                Your data is automatically saved and kept confidential.<br>
-                Participant IDs are anonymized for privacy.
-            </p>
-        </div>
+    </main>
+    <div class="footer">
+        <p>For technical support or questions, contact the research team at action.brain.lab@gallaudet.edu.</p>
+        <p style="margin-top: 10px; font-size: 12px;">
+            Your data is automatically saved and kept confidential.<br>
+            Participant IDs are anonymized for privacy.
+        </p>
     </div>
     <script>
         function startExperiment(){


### PR DESCRIPTION
## Summary
- use semantic `<main>` container on landing page
- ensure footer content is outside main content area

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b0e43abccc8326beda05c3d6bec59e