### PR TITLE
Fix contact info alignment on landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -164,15 +164,16 @@
             </ul>
             <p style="margin-top: 15px;">Your responses help us understand how sign language experience affects spatial thinking.</p>
         </div>
-        
+
+        <div class="footer">
+            <p>For technical support or questions, contact the research team at action.brain.lab@gallaudet.edu.</p>
+            <p style="margin-top: 10px; font-size: 12px;">
+                Your data is automatically saved and kept confidential.<br>
+                Participant IDs are anonymized for privacy.
+            </p>
+        </div>
+
     </main>
-    <div class="footer">
-        <p>For technical support or questions, contact the research team at action.brain.lab@gallaudet.edu.</p>
-        <p style="margin-top: 10px; font-size: 12px;">
-            Your data is automatically saved and kept confidential.<br>
-            Participant IDs are anonymized for privacy.
-        </p>
-    </div>
     <script>
         function startExperiment(){
             window.location.href = 'webversion.html';


### PR DESCRIPTION
## Summary
- keep support contact details readable by moving footer into the main container

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b0e5dc167c8326b8d653c76358d015