### PR TITLE
Hide stimulus visuals from assistive tech

### DIFF
--- a/webversion.html
+++ b/webversion.html
@@ -165,7 +165,7 @@
       <div id="practice-banner" class="nav-type-header"></div>
 
       <div class="stimulus-stage">
-        <img id="stimulus-image" src="" alt="Stimulus">
+        <img id="stimulus-image" alt="" aria-hidden="true">
         <div class="fixation" id="fixation" aria-hidden="true"></div>
       </div>
 


### PR DESCRIPTION
## Summary
- Hide stimulus image and fixation cross from screen readers with `aria-hidden`
- Remove unused `src` and alt text from stimulus image

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b0e8109ed88326958c70eea678b550