### PR TITLE
Wrap footer email with mailto link

### DIFF
--- a/index.html
+++ b/index.html
@@ -166,7 +166,7 @@
         </div>
 
         <div class="footer">
-            <p>For technical support or questions, contact the research team at action.brain.lab@gallaudet.edu.</p>
+            <p>For technical support or questions, contact the research team at <a href="mailto:action.brain.lab@gallaudet.edu">action.brain.lab@gallaudet.edu</a>.</p>
             <p style="margin-top: 10px; font-size: 12px;">
                 Your data is automatically saved and kept confidential.<br>
                 Participant IDs are anonymized for privacy.


### PR DESCRIPTION
## Summary
- wrap technical support email in footer with a mailto link

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b0e8017a488326bfdd4b7b70443f0e