### PR TITLE
Remove automatic participant ID assignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ spatial-navigation-web/
 ## Participant Instructions
 
 1. **Access the Task**: Navigate to the provided URL
-2. **Enter Information**: Fill in participant ID, age, gender, and handedness
+2. **Enter Information**: Fill in initials, participant group, age, gender, and handedness
 3. **Respond Using Controls**: On keyboards press arrow keys; on touch devices use the on-screen D-pad
 4. **Practice Phase**: Complete 4 practice trials with feedback
 5. **Main Experiment**: Complete 9 blocks of 15 trials each
@@ -119,11 +119,6 @@ Counterbalance condition is automatically determined from participant ID (ID mod
 - Check browser popup blocker settings
 - Try a different browser
 - Ensure JavaScript is enabled
-
-### Participant ID Issues
-- IDs should be alphanumeric
-- Avoid special characters
-- Use consistent ID format across participants
 
 ## Data Analysis
 

--- a/google-apps-script.gs
+++ b/google-apps-script.gs
@@ -1,19 +1,10 @@
 /** CONFIG **/ 
 const SHEET_NAME = 'Sheet1';            // change if your sheet name differs
-const GROUPS = ['DF','HF','DNF','HNF','HNS'];
 
 /** Entry points **/
 function doPost(e) {
   try {
     const data = JSON.parse(e.postData.contents || '{}');
-    const action = data.action || 'saveTrial';
-
-    if (action === 'nextIdLocked')      return json(nextIdLocked_(data.groupCode));
-    if (action === 'setCounter')        return json(setCounter_(data.groupCode, data.value));
-    if (action === 'getCounters')       return json(getCounters_());
-    if (action === 'rebuildCounters')   return json(rebuildCountersFromSheet_());
-
-    // Default - save one trial row just like your current script
     appendTrialRow_(data);
     return json({ ok: true });
   } catch (err) {
@@ -88,97 +79,8 @@ function ensureColumns_(sheet) {
   }
 }
 
-/** ID counter with locking **/
-function nextIdLocked_(group) {
-  if (!group) return { ok: false, error: 'groupCode required' };
-
-  const lock = LockService.getScriptLock();
-  lock.waitLock(5000);
-  try {
-    const props = PropertiesService.getScriptProperties();
-    const key = 'counter_' + group;
-    let n = parseInt(props.getProperty(key) || '0', 10);
-    n = n + 1; // reserve the next number
-    props.setProperty(key, String(n));
-    return {
-      ok: true,
-      group: group,
-      number: pad3_(n),
-      id: group + '-online-' + pad3_(n)
-    };
-  } finally {
-    lock.releaseLock();
-  }
-}
-
-/** Admin utilities **/
-function setCounter_(group, value) {
-  if (!group) return { ok: false, error: 'groupCode required' };
-  const n = parseInt(value, 10);
-  if (isNaN(n) || n < 0) return { ok: false, error: 'value must be a non-negative integer' };
-  PropertiesService.getScriptProperties().setProperty('counter_' + group, String(n));
-  return { ok: true, group, value: n };
-}
-
-function getCounters_() {
-  const props = PropertiesService.getScriptProperties().getProperties();
-  const counters = {};
-  GROUPS.forEach(g => counters[g] = parseInt(props['counter_' + g] || '0', 10));
-  return { ok: true, counters: counters, maxima: scanMaximaFromSheet_() };
-}
-
-function rebuildCountersFromSheet_() {
-  const maxima = scanMaximaFromSheet_();
-  const props = PropertiesService.getScriptProperties();
-  Object.keys(maxima).forEach(g => props.setProperty('counter_' + g, String(maxima[g])));
-  return { ok: true, counters: maxima };
-}
-
-function scanMaximaFromSheet_() {
-  const sheet = getSheet_();
-  const values = sheet.getDataRange().getValues();
-  const colParticipantId = 1; // zero-based, column B
-  const reByGroup = {
-    DF: /DF-online-(\d{1,})/i,
-    HF: /HF-online-(\d{1,})/i,
-    DNF:/DNF-online-(\d{1,})/i,
-    HNF:/HNF-online-(\d{1,})/i,
-    HNS:/HNS-online-(\d{1,})/i
-  };
-  const max = { DF:0, HF:0, DNF:0, HNF:0, HNS:0 };
-
-  for (let i = 1; i < values.length; i++) { // start at 1 to skip header
-    const pid = values[i][colParticipantId];
-    if (!pid) continue;
-    const s = String(pid);
-    for (const g in reByGroup) {
-      const m = s.match(reByGroup[g]);
-      if (m) {
-        const n = parseInt(m[1], 10);
-        if (n > max[g]) max[g] = n;
-        break;
-      }
-    }
-  }
-  return max;
-}
-
-/** Utils **/
-function pad3_(n) { return ('000' + n).slice(-3); }
 function json(obj) {
   return ContentService.createTextOutput(JSON.stringify(obj))
     .setMimeType(ContentService.MimeType.JSON);
-}
-
-function initCounters() {
-  // Scan the sheet and store maxima into script properties
-  const res = rebuildCountersFromSheet_();
-  Logger.log(res);
-}
-
-function showCounters() {
-  // Log current stored counters and maxima
-  const res = getCounters_();
-  Logger.log(JSON.stringify(res));
 }
 

--- a/webversion.html
+++ b/webversion.html
@@ -505,24 +505,9 @@ UP / DOWN / LEFT / RIGHT
       if (!group || !initials || !age || !gender || !handedness) return alert('Please fill in all required fields (Initials, Age, Gender, Handedness)');
 
       const btn = document.getElementById('start-button');
-      btn.disabled = true; btn.textContent = 'Assigning ID…';
+      btn.disabled = true;
 
-      // Try server → fallback locally; stays silent if server blocks CORS
-      let assignedId;
-      try {
-        const res = await fetch(GOOGLE_SHEET_URL, {
-          method: 'POST',
-          headers: { 'Content-Type': 'text/plain;charset=utf-8' },
-          body: JSON.stringify({ action: 'nextIdLocked', groupCode: group, initials: initials })
-        });
-        const data = await res.json();
-        if (!data.ok || !data.id) throw new Error('Bad response');
-        assignedId = data.id;
-      } catch {
-        const bytes = new Uint8Array(8); crypto.getRandomValues(bytes);
-        const hex = Array.from(bytes).map(b=>b.toString(16).padStart(2,'0')).join('').slice(0,8);
-        assignedId = `${group}-tmp-${Date.now().toString(36)}-${hex}`;
-      }
+      const assignedId = `${group}-${initials}`;
 
       state.participantInfo = { id: assignedId, initials, group, age, gender, handedness, timestamp: new Date().toISOString() };
       state.sessionCode = assignedId;
@@ -556,7 +541,7 @@ UP / DOWN / LEFT / RIGHT
       setInstructionContinue(()=> { state.isPractice = true; state.currentTrial = 0; runPracticeTrial(); });
       showScreen('instruction-screen');
 
-      btn.disabled = false; btn.textContent = 'Start Experiment';
+      btn.disabled = false;
     }
 
     /********* PRACTICE HELPERS *********/


### PR DESCRIPTION
## Summary
- Simplify start routine by deriving participant ID from group and initials instead of requesting an assigned ID
- Drop Google Apps Script ID counter endpoints and related utilities
- Update instructions to ask for initials and group, removing legacy ID guidance

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c60b98986c8326b0d4feec3cbf0494