### PR TITLE
Add completion reminder to return to main portal

### DIFF
--- a/webversion.html
+++ b/webversion.html
@@ -936,7 +936,8 @@ Task: Just press the key for that first arrow. The player will not move.
         <h2>Experiment Complete!</h2>
         <p>Thank you for participating.</p>
         <p>Your data has been saved.</p>
-        <p>Participant ID: ${state.participantInfo.id}</p>`;
+        <p>Participant ID: ${state.participantInfo.id}</p>
+        <p>You are done with this task. Please return to the main study portal to continue.</p>`;
       txt.style.color = '#333';
       dl.style.display = 'none';
       showScreen('feedback-screen');


### PR DESCRIPTION
## Summary
- extend the completion message shown after the final trial to tell participants they are done
- direct participants to return to the main study portal once the task is complete

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cc45536ff48326a34e34f66f4cbd95